### PR TITLE
Updated module path in go.mod to reflect the new home of the theme

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dwhweb/strath_geeks_theme
+module github.com/StrathearnGeeks/strath_geeks_theme
 
 go 1.16
 


### PR DESCRIPTION
As per title, I've updated the module path in `go.mod` to reflect the new home of the theme files, running the dev server or CI will presumably break without this.